### PR TITLE
merge Voronoi vertices symbolically

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -187,7 +187,7 @@ void write_polygons(int64_t fid, const Mesh& mesh) {
 
   index_t n_boundary = mesh.polygons().n();
   GmfSetKwd(fid, GmfBoundaryPolygonHeaders, n_boundary);
-  std::vector<index_t> headers(mesh.polygons().n());
+  std::vector<long> headers(mesh.polygons().n());
   index_t m = 1;
   size_t np = mesh.polygons().n();
   for (size_t k = 0; k < np; k++) {
@@ -200,8 +200,10 @@ void write_polygons(int64_t fid, const Mesh& mesh) {
               &groups[np - 1]);
 
   GmfSetKwd(fid, GmfBoundaryPolygonVertices, m - 1);
-  std::vector<index_t> v = mesh.polygons().data();
-  for (auto& x : v) x += 1;
+  std::vector<long> v(mesh.polygons().data().size());
+  for (size_t k = 0; k < mesh.polygons().data().size(); k++) {
+    v[k] = mesh.polygons().data()[k] + 1;
+  }
   GmfSetBlock(fid, GmfBoundaryPolygonVertices, 1, m - 1, 0, nullptr, nullptr,
               GmfLong, &v[0], &v[m - 2]);
 }

--- a/src/voronoi.h
+++ b/src/voronoi.h
@@ -253,6 +253,7 @@ class VoronoiDiagram : public Mesh {
   const auto& weights() const { return weights_; }
   void smooth(Vertices& sites) const;
   VoronoiDiagramProperties analyze() const;
+  void merge();
 
  private:
   int dim_;

--- a/src/voronoi_test.cpp
+++ b/src/voronoi_test.cpp
@@ -173,6 +173,7 @@ UT_TEST_CASE(test_square) {
     UT_ASSERT_NEAR(dj, dk, tol);
   }
 
+  voronoi.merge();
   LOG << fmt::format("writing {} polygons", voronoi.polygons().n());
   if (voronoi.polygons().n() > 0) meshb::write(voronoi, "square.meshb");
 }
@@ -278,12 +279,13 @@ UT_TEST_CASE(test_sphere) {
     UT_ASSERT_NEAR(dj, dk, tol);
   }
 
+  voronoi.merge();
   LOG << fmt::format("writing {} polygons", voronoi.polygons().n());
   if (voronoi.polygons().n() > 0) meshb::write(voronoi, "sphere.meshb");
 }
 UT_TEST_CASE_END(test_sphere)
 
-UT_TEST_CASE_SKIP(test_sphere_triangulation) {
+UT_TEST_CASE(test_sphere_triangulation) {
   Sphere sphere(2);
   static const int dim = 3;
   size_t n_sites = 1e4;
@@ -314,6 +316,7 @@ UT_TEST_CASE_SKIP(test_sphere_triangulation) {
     options.verbose = (iter == 1 || iter == n_iter - 1);
     voronoi.vertices().clear();
     voronoi.vertices().set_dim(3);
+    voronoi.triangles().clear();
     voronoi.polygons().clear();
     voronoi.compute(domain, options);
 
@@ -334,6 +337,7 @@ UT_TEST_CASE_SKIP(test_sphere_triangulation) {
     voronoi.polygons().set_group(k, site2color[group]);
   }
 
+  voronoi.triangles().clear();  // not implemented yet
   LOG << fmt::format("writing {} polygons", voronoi.polygons().n());
   if (voronoi.polygons().n() > 0)
     meshb::write(voronoi, "sphere_triangulation.meshb");

--- a/src/vortex.cpp
+++ b/src/vortex.cpp
@@ -319,6 +319,11 @@ void run_voronoi(argparse::ArgumentParser& program) {
     calculate_voronoi_diagram(domain);
   }
 
+  if (using_mesh)
+    voronoi.triangles().clear();
+  else
+    voronoi.merge();
+
   // randomize the colors a bit, otherwise neighboring cells
   // will have similar colors and won't visually stand out
   size_t n_colors = 20;


### PR DESCRIPTION
### Summary

This PR merges Voronoi vertices that share identical bisector information (i.e. they represent the same Delaunay triangle), which also reduces the size of the output mesh. It's still possible for some vertices to have the same coordinates since exact predicates are not used yet.

### Testing

Visualized meshes using Vizir (https://pyamg.saclay.inria.fr/vizir4.html) - adjacent polygons share the same vertices:

<img width="300" alt="vizir0" src="https://github.com/middpolymer/vortex/assets/15183590/d1a2d497-de50-4714-b372-cf36105d34e6"> <img width="300" alt="vizir1" src="https://github.com/middpolymer/vortex/assets/15183590/76ebfc64-2e7f-4ea3-a49c-4e7f5b787827">

