### PR TITLE
only show vertex numbers for picked element

### DIFF
--- a/src/shaders/text-gs.glsl
+++ b/src/shaders/text-gs.glsl
@@ -8,6 +8,7 @@ uniform mat4 u_ModelViewProjectionMatrix;
 flat out int v_number;
 
 uniform samplerBuffer points;
+uniform usamplerBuffer visibility;
 
 // TODO pass uniforms
 float width = 800;
@@ -29,6 +30,8 @@ void main() {
 
   // retrieve point number and initial point coordinates
   int n = v_id[0];
+  int visible = int(texelFetch(visibility, n).r);
+  if (visible == 0) return;
   vec3 p = texelFetch(points, n).xyz;
   vec4 q = u_ModelViewProjectionMatrix * vec4(p * 1.001, 1);
 


### PR DESCRIPTION
### Summary

This PR adds a buffer to store visibility information for each vertex which can be set to 1 if a vertex is visible. The default is to plot all vertices, but when an element is picked, the data in the buffer is set to 1 for vertices of the picked element, and 0 for all others.

### Testing

<img width="500" alt="picked-visibility" src="https://github.com/middleburygcl/vortex/assets/15183590/8e3446ec-3020-431b-bb6b-200a122e3b05">
