### PR TITLE
always use 3d coordinates in grid, fix orientation of number texture

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -606,6 +606,7 @@ class MeshScene : public wings::Scene {
     // write font texture
     f = std::string(VORTEX_SOURCE_DIR) + "/../data/monaco-numbers.png";
     tex_opts.format = TextureFormat::kRGBA;
+    tex_opts.flipy = false;
     Texture font(f, tex_opts);
     GL_CALL(glBindTexture(GL_TEXTURE_2D, font_texture_));
     GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, font.width(), font.height(),

--- a/src/graphics_test.cpp
+++ b/src/graphics_test.cpp
@@ -33,7 +33,7 @@ UT_TEST_CASE(test1) {
   //  Grid<Triangle> mesh({10, 10}, 3);
   //  Mesh mesh(3);
   //  meshb::read("water.meshb", mesh);
-  Grid<Quad> mesh({10, 10}, 3);
+  Grid<Quad> mesh({10, 10});
   mesh.fields().set_defaults(mesh);
 #if VORTEX_FULL_UNIT_TEST == 0
   Viewer viewer(mesh, 7681);

--- a/src/halfedges_test.cpp
+++ b/src/halfedges_test.cpp
@@ -35,7 +35,7 @@ UT_TEST_CASE(test_closed) {
 UT_TEST_CASE_END(test_closed)
 
 UT_TEST_CASE(test_open) {
-  Grid<Triangle> mesh({10, 10}, 3);
+  Grid<Triangle> mesh({10, 10});
   HalfMesh hmesh(mesh);
   UT_ASSERT(hmesh.check());
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -27,8 +27,7 @@
 namespace vortex {
 
 template <typename type>
-Grid<type>::Grid(const std::vector<int>& sizes, int dim)
-    : Mesh((dim < 0) ? sizes.size() : dim), sizes_(sizes) {
+Grid<type>::Grid(const std::vector<int>& sizes) : Mesh(3), sizes_(sizes) {
   build();
 }
 
@@ -43,13 +42,13 @@ void Grid<Triangle>::build() {
   vertices_.reserve((nx + 1) * (ny + 1));
   triangles_.reserve(2 * nx * ny);
 
-  std::vector<double> x(vertices_.dim(), 0.0);
+  double x[3] = {0, 0, 0};
   for (int j = 0; j < ny + 1; j++) {
     for (int i = 0; i < nx + 1; i++) {
       x[0] = i * dx;
       x[1] = j * dy;
 
-      vertices_.add(x.data());
+      vertices_.add(x);
     }
   }
 
@@ -86,13 +85,13 @@ void Grid<Quad>::build() {
   vertices_.reserve((nx + 1) * (ny + 1));
   quads_.reserve(nx * ny);
 
-  std::vector<double> x(vertices_.dim(), 0.0);
+  double x[3] = {0, 0, 0};
   for (int j = 0; j < ny + 1; j++) {
     for (int i = 0; i < nx + 1; i++) {
       x[0] = i * dx;
       x[1] = j * dy;
 
-      vertices_.add(x.data());
+      vertices_.add(x);
     }
   }
 
@@ -125,13 +124,13 @@ void Grid<Polygon>::build() {
   vertices_.reserve((nx + 1) * (ny + 1));
   polygons_.reserve(nx * ny);
 
-  std::vector<double> x(vertices_.dim(), 0.0);
+  double x[3] = {0, 0, 0};
   for (int j = 0; j < ny + 1; j++) {
     for (int i = 0; i < nx + 1; i++) {
       x[0] = i * dx;
       x[1] = j * dy;
 
-      vertices_.add(x.data());
+      vertices_.add(x);
     }
   }
 

--- a/src/library.h
+++ b/src/library.h
@@ -35,13 +35,8 @@ class Grid : public Mesh {
    *            for a 1d mesh (Line), sizes.size() = 1
    *            for a 2d mesh (Triangle, Quad) sizes.size() = 2
    *            for a 3d mesh (Tet), sizes.size() = 3
-   * \param[in] dim - Dimension of the vertices.
-   *                  Sometimes you may want to create a mesh in 3d even if
-   *                  the mesh is really in 2d. When the default of -1 is used
-   *                  then the ambient dimension becomes the topological
-   * dimension of the element.
    */
-  Grid(const std::vector<int>& sizes, int dim = -1);
+  Grid(const std::vector<int>& sizes);
 
   /**
    * \brief Builds the structured mesh


### PR DESCRIPTION
### Summary

The `Grid<T>` class is now always defined in 3d. This PR also fixes the orientation of the numbers when an element is picked.

### Testing

Unit tests still pass.