### PR TITLE
click points on sphere and print coordinates

### DIFF
--- a/src/shaders/points-vs.glsl
+++ b/src/shaders/points-vs.glsl
@@ -5,5 +5,5 @@ uniform mat4 u_ModelViewProjectionMatrix;
 
 void main() {
   gl_Position = u_ModelViewProjectionMatrix * vec4(a_Position, 1.0);
-  gl_PointSize = 5.0 / gl_Position.w;
+  gl_PointSize = 25.0 / gl_Position.w;
 }

--- a/vortex.html
+++ b/vortex.html
@@ -277,6 +277,16 @@
             </select>
           </div>
           <div class="form-check" style="display: inline-block">
+            <select
+              class="form-select"
+              id="dropdown-picking-type"
+              onchange="togglePicking();"
+            >
+              <option>mesh</option>
+              <option>sphere</option>
+            </select>
+          </div>
+          <div class="form-check" style="display: inline-block">
             <label class="form-check-label" id="size-label"></label>
           </div>
           <br />
@@ -455,7 +465,8 @@
     );
 
     img.addEventListener("dblclick", function (e) {
-      const x = ("0000" + e.offsetX).slice(-5);
+      let X = e.pageX - e.target.offsetLeft;
+      const x = ("0000" + X).slice(-5);
       const y = ("0000" + e.offsetY).slice(-5);
       const msg = "D" + x + y;
       ws.send(msg);
@@ -539,6 +550,11 @@
     const toggleNumbers = () => {
       const dropdown = document.getElementById("dropdown-vertex-numbers");
       ws.send("KI#" + dropdown.selectedIndex);
+    };
+
+    const togglePicking = () => {
+      const dropdown = document.getElementById("dropdown-picking-type");
+      ws.send("KIx" + dropdown.selectedIndex);
     };
 
     const setHeight = () => {


### PR DESCRIPTION
### Summary

Adds functionality for clicking a sphere and printing the clicked coordinates (in the `vortex` UI as well as the terminal). An additional dropdown has been added to switch between element (mesh) picking and sphere picking. The latter option needs to be selected to activate the sphere clicking. Clicked points are also saved and rendered as circles in the scene.

The x-coordinate seems slightly off in some cases (requires further investigation), but this seems to work well when clicking a point close to the center of the view.

### Testing

Three points were clicked below. The latest coordinates are printed in the `vortex` UI.

<img width="800" alt="sphere-clicking" src="https://github.com/middleburygcl/vortex/assets/15183590/dc821de9-173e-4e2b-82d8-fbc118660195">

