### PR TITLE
ignore extern directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build*
+extern*
 test
 data/*.obj
 data/*.meshb


### PR DESCRIPTION
### Summary

Ignores the `extern` directory where third-party libraries are downloaded.

### Testing

n/a

### TODO

n/a