### PR TITLE
add input for `--resolution` (in terms of km) which then calculates # points (on sphere)

### DIFF
--- a/src/vortex.cpp
+++ b/src/vortex.cpp
@@ -462,12 +462,19 @@ void run_merge(argparse::ArgumentParser& program) {
 
 void run_simulation(argparse::ArgumentParser& program) {
   const int dim = 3;
-  size_t n_points = program.get<int>("--n_particles");
+  auto arg_domain = program.get<std::string>("--domain");
+  auto resolution = program.get<double>("--resolution");
+  size_t n_points;
+  double earth_area = 4 * M_PI * std::pow(6378, 2);
+  if (arg_domain == "sphere" && resolution > 0) {
+    n_points = (int)(earth_area / std::pow(resolution, 2));
+  } else {
+    n_points = program.get<int>("--n_particles");
+  }
   auto corners = program.get<std::vector<double>>("--corners");
 
   Vertices sample(3);
   auto arg_points = program.get<std::string>("--particles");
-  auto arg_domain = program.get<std::string>("--domain");
   auto irand = [](int min, int max) {
     return min + double(rand()) / (double(RAND_MAX) + 1.0) * (max - min);
   };


### PR DESCRIPTION
### Summary
This PR adds an input `--resolution` for various vortex subprograms that currently require the number of points (e.g., `--n_points`). When the domain is a sphere, the `--resolution` argument allows users to specify the approximate size of the cell in kilometers. The number of points is then calculated based on the surface area of the Earth, by the formula:
$$n = \frac{4 \pi R^2}{\text{resolution}^2}$$, where $R$ is the radius of the Earth.


### Testing
Manually verified that the number of points is correctly calculated based on the given resolution.
Also verified if both `--n_points` and `--resolution` are given, `--resolution` will be used to calculate the number of points.
No unit tests added.

### TODO
Do I need to write tests for this?