### PR TITLE
unit tests for library_test.cpp

### DIFF
--- a/src/library_test.cpp
+++ b/src/library_test.cpp
@@ -92,7 +92,7 @@ UT_TEST_CASE_END(grid_quad_test)
 
 UT_TEST_CASE(grid_polygon_test) {
   // testing the number of vertices and polygons in a polygon mesh
-  double tol = 1e-12;
+  double tol = 1e-10;
   for (int i = 1; i < 6; i++) {
     for (int j = 1; j < 6; j++) {
       int nx = i * 100;


### PR DESCRIPTION
### Summary
Added unit tests to ensure the correct number of triangles, vertices, and quads were being created in triangle, quad, and icosahedron meshes.  Also ensured that the sum area of every triangle, quad, or spherical triangle was equal to 1 (for triangle and quad meshes) or converged to 4pi (for icosahedron meshes).

### Testing
Implemented the tests described above.

### TODO
Zeyi and I worked together on this issue.  After this PR is merged, she'll just have to merge the unit tests she wrote for polygon meshes.