### PR TITLE
additional testing for nlopt.cpp

### DIFF
--- a/src/nlopt_test.cpp
+++ b/src/nlopt_test.cpp
@@ -290,7 +290,7 @@ UT_TEST_CASE(test3) {
   nlopt::result result = opt_rosen3d.optimize(X, rosen3d_opt);
 
   // discretized min check
-  int N = 25000;
+  int N = 5000;
   double min = std::numeric_limits<double>::max();
   double delta_theta = (2 * M_PI) / N;
   double delta_phi = M_PI / N;
@@ -327,9 +327,9 @@ UT_TEST_CASE(test3) {
   // check that the minimum val and x1, x2, x3 coords on the constraint is
   // roughly equal to the value returned from optimization
   UT_ASSERT_NEAR(min, rosen3d_opt, 1e-4);
-  UT_ASSERT_NEAR(X[0], xm, 1e-4);
-  UT_ASSERT_NEAR(X[1], ym, 1e-4);
-  UT_ASSERT_NEAR(X[2], zm, 1e-4);
+  UT_ASSERT_NEAR(X[0], xm, 1e-3);
+  UT_ASSERT_NEAR(X[1], ym, 1e-3);
+  UT_ASSERT_NEAR(X[2], zm, 1e-3);
 
   // UT_ASSERT_EQUALS(result, nlopt::SUCCESS);
 }


### PR DESCRIPTION
### Summary
Added some more testing in `nlopt.cpp`

### Testing
On the Rosenbrock function, tested `LD_SLSQP` optimizer with a circle and sphere (unit sphere) constraint for the 2D and 3D versions of the function respectively.  On the Booth function, tested `LD_LBFGS` (and `LN_COBYLA` though not currently implemented).

For function definitions: https://en.wikipedia.org/wiki/Test_functions_for_optimization

### TODO
Build off of these tests to use a gradient-based method for optimized point-smoothing (i.e. Issue #52)