### PR TITLE
tests for bounding box and zcurve sorting

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -164,4 +164,5 @@ double irand(int min, int max) {
 
 }  // namespace vortex
 
-template void vortex::get_bounding_box<double>(const double*, int64_t, int8_t, double*, double*);
+template void vortex::get_bounding_box<double>(const double*, int64_t, int8_t,
+                                               double*, double*);

--- a/src/util_test.cpp
+++ b/src/util_test.cpp
@@ -99,8 +99,8 @@ UT_TEST_CASE_END(test_sort_points_on_zcurve_one_z)
 
 UT_TEST_CASE(test_sort_points_on_z_curve_grid) {
   const int dim = 3;
-  const int nx = 4;
-  const int ny = 4;
+  const int nx = 20;
+  const int ny = 20;
 
   Grid<Quad> grid({nx, ny});
 


### PR DESCRIPTION
### Summary
Added tests for the bounding box and z-curve sorting (one test for a single z and one for a grid)


### Testing
The bounding box and the single z tests worked. It definitely looks like the sorting on the grid failed. It could very well be that the test itself isn't correct but I am fairly certain that it is. As you can see this is not right:
<img width="442" alt="Screenshot 2025-06-30 at 1 27 23 PM" src="https://github.com/user-attachments/assets/7cb95e4b-78f8-4356-ba51-680adc5fbee0" />
