### PR TITLE
calculate vorticity and include in vtk files

### DIFF
--- a/src/operators.h
+++ b/src/operators.h
@@ -38,7 +38,7 @@ class VoronoiOperators {
   void set_method(OperatorMethod m) { method_ = m; }
   void calculate_gradient(const coord_t* f, coord_t* grad_f);
   void calculate_divergence(const coord_t* u, coord_t* div_u);
-  void calculate_relative_vorticity(const coord_t* u, coord_t* w);
+  void calculate_curl(const coord_t* u, coord_t* w);
 
  private:
   const VoronoiDiagram& voronoi_;

--- a/src/shallow_water_cases.cpp
+++ b/src/shallow_water_cases.cpp
@@ -143,8 +143,6 @@ WilliamsonCase5::WilliamsonCase5() {
     double d = std::min(R * R, d_lambda * d_lambda + d_theta * d_theta);
     double hs = hs0 * (1 - std::pow(d, 0.5) / R);
     // return hs0 * std::exp(-2.8 * 2.8 * d / (R * R));
-    //  ASSERT(hs >= 0) << hs;
-    //   if (hs > 0) LOG << hs;
     return hs;
   };
   initial_height = [a, omega, g, u0, h0](const double* x) -> double {


### PR DESCRIPTION
### Summary

EDIT: the method described below is kept for reference, though the vorticity is now calculated using operators that are similar to how the gradient and divergence are calculated since unit testing revealed it might be more accurate.

------

Approximates the vorticity component normal to the sphere using Stokes' theorem over a spherical Voronoi cell $V_i$:

$$
\int_{V_i} \vec{\omega}\cdot \vec{n}\mathrm{d}S = \int\limits_{V_i} (\nabla \times \vec{u}) \cdot \vec{n} \mathrm{d}S = \oint_{\partial V_i} \vec{u}\cdot \mathrm{d}\vec{l} = \sum_{f \in \partial V_i} \vec{u}_f \cdot \vec{e}_f.
$$

So the relative vorticity normal to the sphere $\zeta$ is:

$$
\zeta = \frac{1}{\lvert V_i\rvert}  \sum_{f \in \partial V_i} \vec{u}_f \cdot \vec{e}_f.
$$

with $\vec{u}_f = \left(\vec{u}_i + \vec{u}_j\right)/2$ (average of site velocities adjacent to the shared edge $f$) and $\vec{e}_f$ is the vector (direction and length) along the shared edge, counterclockwise around the Voronoi cell.

The potential vorticity $q$ is then:

$$
q = \frac{\zeta + f}{h}
$$

with $f$ the Coriolis parameter and $h$ is the height of the fluid. The `.vtk` files now include height, relative vorticity and potential vorticity fields.

### Testing

Added a unit test in a square. Visualizing the results on Williamson Test Case 5, which seems consistent with `swe-python` though the vorticity fields seem a bit noisy. Here is the potential vorticity and then relative vorticity at 15 days (icosahedron6, $\Delta t$ = 1 minute):

<img width="3238" height="1602" alt="pv" src="https://github.com/user-attachments/assets/8b5c8fa7-6585-46ba-9d67-733e4d674e12" />

<img width="3238" height="1602" alt="rv" src="https://github.com/user-attachments/assets/5eb80191-db56-49e0-a5c0-bdcf9d4c932f" />

And here are the results using first method I tried (with Stokes' theorem):

<img width="2200" height="1260" alt="w5-15days" src="https://github.com/user-attachments/assets/a354a905-50c6-4812-a245-767e3d645b19" />

<img width="2200" height="1260" alt="relative-vorticity" src="https://github.com/user-attachments/assets/ac37a690-a5e2-403a-a605-ae3a29a3abcc" />
