### PR TITLE
spherical quadtree improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 `vortex` is a Voronoi mesher, visualizer and fluid simulator for geophysical fluids on the sphere. Currently, the main capability consists of solving the shallow water equations with a Lagrangian method to simulate the air in the Earth's atmosphere. Future work consists of applying this method to simulate the oceans.
 
-**Note:** `vortex` currently contains new unpublished research which is why it is a private repository - please do not share the code with anyone. It could be released publicly after the ideas are published.
-
 ### Installation
 
 To get started, `vortex` only requires `git`, `CMake` and a `C++` compiler that supports `C++17`. The `CMake` configuration will automatically download all required dependencies to the `extern` directory (which will be ignored by `git`). If you need to update a dependency (e.g. `wings`), delete the `extern/wings` directory and re-run the `CMake` configuration in your build directory.

--- a/src/neighbors.cpp
+++ b/src/neighbors.cpp
@@ -113,10 +113,15 @@ SphereQuadtree::Subdivision::Subdivision(int np, int ns)
     int k = MAX_NEIGHBOR_CAPACITY;
     int n = np;
     int m = double(k) / kOneRingSize;
-    ns = std::floor(std::log(n / (T ::n_faces * m)) / std::log(4.0));
+    ns = std::floor(std::log(n / (T ::n_faces * m)) / std::log(4.0)) + 1;
   }
+set_levels:
   n_levels = ns + 1;
   n_points_per_triangle = np / (Octahedron::n_faces * std::pow(4, ns));
+  if (n_points_per_triangle < 10) {
+    ns--;
+    goto set_levels;
+  }
   LOG << fmt::format("# levels = {}, # triangles = {}, # pts/tri ~ {}",
                      n_levels, t_last(ns) - t_first(ns), n_points_per_triangle);
 

--- a/src/neighbors.cpp
+++ b/src/neighbors.cpp
@@ -243,10 +243,11 @@ void SphereQuadtree::setup() {
 
 void SphereQuadtree::build() {
   // utility to determine if a point is inside a spherical triangle
+  static const double tol = -1e-8;
   auto intriangle = [](const vec3d& v0, const vec3d& v1, const vec3d& v2,
                        const vec3d& v) {
-    return dot(cross(v0, v1), v) >= 0 && dot(cross(v1, v2), v) >= 0 &&
-           dot(cross(v2, v0), v) >= 0;
+    return dot(cross(v0, v1), v) >= tol && dot(cross(v1, v2), v) >= tol &&
+           dot(cross(v2, v0), v) >= tol;
   };
 
   int last_level = mesh_.n_levels - 1;

--- a/src/voronoi.cpp
+++ b/src/voronoi.cpp
@@ -944,7 +944,6 @@ VoronoiDiagramProperties VoronoiDiagram::analyze() const {
   props.area = 0.0;
   double c = 0.0;
   for (size_t k = 0; k < n_sites_; k++) {
-    // props.area += properties_[k].volume;
     double y = properties_[k].volume - c;  // Kahan sum
     double t = props.area + y;
     c = (t - props.area) - y;

--- a/src/voronoi.cpp
+++ b/src/voronoi.cpp
@@ -941,8 +941,14 @@ void VoronoiDiagram::smooth(Vertices& sites, bool on_sphere) const {
 VoronoiDiagramProperties VoronoiDiagram::analyze() const {
   // TODO(philip) calculate energy and gradient norms
   VoronoiDiagramProperties props;
+  props.area = 0.0;
+  double c = 0.0;
   for (size_t k = 0; k < n_sites_; k++) {
-    props.area += properties_[k].volume;
+    // props.area += properties_[k].volume;
+    double y = properties_[k].volume - c;  // Kahan sum
+    double t = props.area + y;
+    c = (t - props.area) - y;
+    props.area = t;
   }
   return props;
 }

--- a/src/vortex.cpp
+++ b/src/vortex.cpp
@@ -134,6 +134,15 @@ void run_visualizer(argparse::ArgumentParser& program) {
   }
 
   mesh.fields().set_defaults(mesh);
+
+  auto save = program.get<std::string>("--save");
+  if (!save.empty()) {
+    // -1 is a signal to not start the rendering server
+    Viewer viewer(mesh, -1, view);
+    viewer.save(save, program);
+    return;
+  }
+
   Viewer viewer(mesh, port, view);
 }
 

--- a/src/vortex.cpp
+++ b/src/vortex.cpp
@@ -540,7 +540,7 @@ void run_voronoi(argparse::ArgumentParser& program) {
     {
       Mesh tmp(dim);
       points.copy(tmp.vertices());
-      meshb::write(tmp, program.get<std::string>("--output_points") + ".meshb");
+      meshb::write(tmp, output_points + ".meshb");
     }
     {
       std::string filename = output_points + ".dat";

--- a/src/vortex.cpp
+++ b/src/vortex.cpp
@@ -391,6 +391,12 @@ void run_voronoi(argparse::ArgumentParser& program) {
       }
     } else
       sample_surface(background_mesh, sample, n_points);
+  } else if (arg_points == "icosahedron") {
+    int n_points_subdiv = program.get<int>("--n_points_subdiv");
+    SubdividedSphere<Icosahedron> subdiv(n_points_subdiv);
+    for (size_t k = 0; k < subdiv.vertices().n(); k++) {
+      sample.add(subdiv.vertices()[k]);
+    }
   } else if (arg_points == "random_oceans") {
     sample.reserve(n_points);
     std::string tex_file =
@@ -522,12 +528,14 @@ void run_voronoi(argparse::ArgumentParser& program) {
   if (program.present<std::string>("--output_points")) {
     auto output_points = program.get<std::string>("--output_points");
     auto ext = get_file_ext(output_points);
-    if (ext == "meshb") {
+    {
       Mesh tmp(dim);
       points.copy(tmp.vertices());
-      meshb::write(tmp, program.get<std::string>("--output_points"));
-    } else if (ext == "txt" || ext == "dat") {
-      FILE* fid = fopen(output_points.c_str(), "w");
+      meshb::write(tmp, program.get<std::string>("--output_points") + ".meshb");
+    }
+    {
+      std::string filename = output_points + ".dat";
+      FILE* fid = fopen(filename.c_str(), "w");
       for (size_t k = 0; k < points.n(); k++)
         fprintf(fid, "%1.16e %1.16e %1.16e\n", points[k][0], points[k][1],
                 points[k][2]);
@@ -814,6 +822,12 @@ int main(int argc, char** argv) {
   cmd_voronoi.add_description("calculate Voronoi diagram on surface");
   cmd_voronoi.add_argument("--domain")
       .help("input surface: (.obj or .meshb), sphere or icosahedron");
+  cmd_voronoi.add_argument("--n_points_subdiv")
+      .default_value(5)
+      .help(
+          "# subdivisions of icosahedron used if this is used for point "
+          "initialization")
+      .scan<'i', int>();
   cmd_voronoi.add_argument("--n_subdiv")
       .help(
           "number of subdivisions of the sphere mesh (only applicable to "


### PR DESCRIPTION
### Summary

This PR mostly improves the spherical quadtree by (1) improving the heuristic to determine the number of subdivisions and (2) to relax the `intriangle` check when points are close to the triangle edges/corners.

Otherwise, there are a few small changes to allow icosahedron points to be used to test the Voronoi diagram subprogram, for example:

```sh
bin/vortex voronoi --domain sphere --points icosahedron --n_points_subdiv 10
```

This will test the Voronoi diagram calculation with sites taken as the vertices of a subdivided icosahedron (subdivided 10 times).

There is also a bug fix to allow general mesh renderings to be saved (not just from a `.json` input mesh). 

Also removed the note about `vortex` being a private repository since it is public now.

### Testing

The recently submitted paper includes the latest Voronoi timing results with these changes.

[voronoi-performance.pdf](https://github.com/user-attachments/files/21719419/voronoi-performance.pdf)

