### PR TITLE
add some scripts to analyze results

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,4 +86,4 @@ jobs:
         python-version: '3.12'
         cache: 'pip'
     - run: pip install -r scripts/requirements.txt
-    - run: python -m pylint scripts/*.py
+    - run: python -m pylint --rc-file scripts/.pylintrc scripts/*.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: c++-checks
+name: checks
 
 on:
   pull_request:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,8 +77,13 @@ jobs:
       run: |
         make unit_coverage
 
-    # - name: upload artifacts
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: output
-    #     path: unit_tests_output.txt
+  py-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - run: pip install -r scripts/requirements.txt
+    - run: python -m pylint scripts/*.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### About
 
-`vortex` is a Voronoi mesher, visualizer and fluid simulator for geophysical fluids on the sphere. Currently, the main capability consists of solving the shallow water equations with a Lagrangian method to simulate the air in the Earth's atmosphere (see Example 9 below). Future work consists of applying this method to simulate the oceans.
+`vortex` is a Voronoi mesher, visualizer and fluid simulator for geophysical fluids on the sphere. Currently, the main capability consists of solving the shallow water equations with a Lagrangian method to simulate the air in the Earth's atmosphere (see [Example 9 below](https://github.com/philipclaude/vortex?tab=readme-ov-file#9-shallow-water-equation-fluid-simulations)). Future work consists of applying this method to simulate the oceans.
 
 The methods implemented in `vortex` are described in the following preprint:
 

--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -1,0 +1,644 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.9
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='  '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: text, parseable, colorized,
+# json2 (improved json format), json (old json format) and msvs (visual
+# studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ scipy
 numpy
 matplotlib
 netCDF4
+pylint

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+scipy
+numpy
+matplotlib
+netCDF4

--- a/scripts/swediff.py
+++ b/scripts/swediff.py
@@ -1,0 +1,86 @@
+'''
+Program to compare vortex solutions with swe-python.
+'''
+import argparse
+import json
+import netCDF4 as nc
+from scipy.spatial import KDTree
+import numpy as np
+from matplotlib import pyplot as plt
+
+def main(src, ref, n_days, out):
+  '''
+  Compares all vortex solutions (in src) with the reference solution.
+  '''
+  plt.style.use('tableau-colorblind10')
+  days = list(range(n_days + 1))
+  for s in src:
+
+    h_error = []
+    for day in range(0, n_days + 1):
+
+      hour = day * 24
+      vtx_file = f"{s}/particles{hour}.json"
+      with open(vtx_file, encoding='utf-8') as f:
+        vtx_data = json.loads(f.read())
+        xp = vtx_data["x"]
+        yp = vtx_data["y"]
+        zp = vtx_data["z"]
+        hp = vtx_data["h"]
+
+      data = nc.Dataset(ref, "r", format="NETCDF4")
+      a = data.sphere_radius
+
+      h = data.variables["hh_cell"][day, :, :]
+      xc = np.array(data["xCell"])
+      yc = np.array(data["yCell"])
+      zc = np.array(data["zCell"])
+      n_cells = len(xc)
+      assert len(yc) == n_cells and len(zc) == n_cells
+
+      # build a kdtree from the stationary points (cell centers)
+      points = np.zeros([n_cells, 3])
+      points[:, 0] = xc
+      points[:, 1] = yc
+      points[:, 2] = zc
+      tree = KDTree(points)
+
+      error = 0
+      n_particles = len(xp)
+      sum_h = 0
+      for i in range(n_particles):
+        # get closest point and height value
+        info = tree.query([a * xp[i], a * yp[i], a * zp[i]])
+        ha = h[info[1]][0]
+        error += (ha - hp[i]) ** 2
+        sum_h += ha ** 2
+      eh = (error / sum_h) ** 0.5
+      print(f"Day {day}: error = {eh}")
+      h_error.append(eh)
+
+    plt.semilogy(days, h_error, '-o', label=f'{n_particles} particles')
+
+  plt.xlabel('day', size=14)
+  plt.ylabel(r'$\Delta I_h$', rotation=0, loc='top', labelpad=-20, size=14)
+  plt.xlim([0, n_days])
+  days_label = list(range(0, n_days + 1, n_days // 3))
+  plt.xticks(ticks=days_label, labels=days_label, size='large')
+  plt.yticks(size='large')
+  plt.grid('major', axis='y')
+  plt.legend(frameon=False, prop={'size': 14}, loc='lower right')
+  plt.savefig(out)
+  plt.show()
+
+if __name__ == "__main__":
+  # Example run using vortex solutions for Williamson test case 5 (w5) with a time step of 30 seconds (t30)
+  # using 5, 6 and 7 icosahedron subdivisions to initialize the particles (i5, i6, i7):
+  # python3.11 swediff.py --ref out_wtc5-cvt8.nc --src w5-i5-t30/ w5-i6-t30/ w5-i7-t30/ --out w5-difference.pdf --days 15
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--src', type=str, nargs='+',
+                      help='list of directories containing particles*.json files')
+  parser.add_argument('--ref', help='reference NetCDF file from swe-python')
+  parser.add_argument('--days', type=int, help='# days to plot')
+  parser.add_argument('--out', help='output file with comparison')
+  args = parser.parse_args()
+  assert args.src and args.ref and args.out
+  main(args.src, args.ref, args.days, args.out)

--- a/scripts/swediff.py
+++ b/scripts/swediff.py
@@ -3,7 +3,8 @@ Program to compare vortex solutions with swe-python.
 '''
 import argparse
 import json
-import netCDF4 as nc
+# pylint: disable=no-name-in-module
+from netCDF4 import Dataset
 from scipy.spatial import KDTree
 import numpy as np
 from matplotlib import pyplot as plt
@@ -28,7 +29,7 @@ def main(src, ref, n_days, out):
         zp = vtx_data["z"]
         hp = vtx_data["h"]
 
-      data = nc.Dataset(ref, "r", format="NETCDF4")
+      data = Dataset(ref, "r", format="NETCDF4")
       a = data.sphere_radius
 
       h = data.variables["hh_cell"][day, :, :]
@@ -72,9 +73,11 @@ def main(src, ref, n_days, out):
   plt.show()
 
 if __name__ == "__main__":
-  # Example run using vortex solutions for Williamson test case 5 (w5) with a time step of 30 seconds (t30)
-  # using 5, 6 and 7 icosahedron subdivisions to initialize the particles (i5, i6, i7):
-  # python3.11 swediff.py --ref out_wtc5-cvt8.nc --src w5-i5-t30/ w5-i6-t30/ w5-i7-t30/ --out w5-difference.pdf --days 15
+  # Example run using vortex solutions for Williamson test case 5 (w5)
+  # with a time step of 30 seconds (t30) using 5, 6 and 7 icosahedron
+  # subdivisions to initialize the particles (i5, i6, i7):
+  # python3.11 swediff.py --ref out_wtc5-cvt8.nc --src w5-i5-t30/ w5-i6-t30/ w5-i7-t30/
+  #                       --out w5-difference.pdf --days 15
   parser = argparse.ArgumentParser()
   parser.add_argument('--src', type=str, nargs='+',
                       help='list of directories containing particles*.json files')

--- a/scripts/sweplot.py
+++ b/scripts/sweplot.py
@@ -28,7 +28,7 @@ def hs5(l, t):
   hs = hs0 * (1 - d ** 0.5 / r)
   return hs
 
-def main(name, src, out):
+def main(name, plot_type, src, out):
   '''
   Runs the main plotting program.
   '''
@@ -54,11 +54,17 @@ def main(name, src, out):
         h = d
 
       # plot
-      s = plt.scatter(l, t, c=h, cmap='coolwarm', s=5, edgecolors='none')
-      cbar = plt.colorbar(s, orientation='vertical', location='right', fraction=0.05, shrink=0.675)
-      cbar.ax.set_title('[m]', pad=10)
-      color_values = [round(min(h))] + SETUP[name]['height_labels'] + [round(max(h))]
-      cbar.set_ticks(color_values)
+      if plot_type == 'point':
+        s = plt.scatter(l, t, c=h, cmap='coolwarm', s=5, edgecolors='none')
+        cbar = plt.colorbar(s, orientation='vertical', location='right',
+                            fraction=0.05, shrink=0.675)
+        cbar.ax.set_title('[m]', pad=10)
+        color_values = [round(min(h))] + SETUP[name]['height_labels'] + [round(max(h))]
+        cbar.set_ticks(color_values)
+      elif plot_type == 'tri':
+        raise TypeError("not implemented yet")
+      else:
+        raise TypeError(f"unknown plot type {plot_type}")
 
       plt.xlabel('$\\lambda$')
       plt.ylabel('$\\theta$', rotation=0)
@@ -85,6 +91,7 @@ if __name__ == '__main__':
   parser.add_argument('--name', help='case to plot: either w2, w5 or w6')
   parser.add_argument('--src', help='directory containing particles*.json files')
   parser.add_argument('--out', help='output directory for images')
+  parser.add_argument('--type', help='either point or tri', default='point')
   args = parser.parse_args()
   assert args.name and args.src and args.out
-  main(args.name, args.src, args.out)
+  main(args.name, args.type, args.src, args.out)

--- a/scripts/sweplot.py
+++ b/scripts/sweplot.py
@@ -1,0 +1,90 @@
+'''
+Program to create images from vortex .json particle output.
+'''
+import json
+import math
+import argparse
+import matplotlib.pyplot as plt
+
+# times are in hours, height_labels are in metres
+SETUP = {
+  'w2': { 'times': [0, 120, 288], 'height_labels': [1500, 2000, 2500]},
+  'w5': { 'times': [0, 120, 240, 360], 'height_labels': [5250, 5500, 5750]},
+  'w6': { 'times': [0, 120, 240, 360], 'height_labels': [8500, 9000, 9500, 10000]},
+}
+
+def hs5(l, t):
+  '''
+  Calculates the surface height for Williamson Case 5 because the vortex
+   .json files only save the depth.
+  '''
+  hs0 = 2000
+  r = math.pi / 9.0
+  lambda_c = -math.pi / 2
+  theta_c = math.pi / 6
+  d_lambda = l - lambda_c
+  d_theta = t - theta_c
+  d = min(r * r, d_lambda * d_lambda + d_theta * d_theta)
+  hs = hs0 * (1 - d ** 0.5 / r)
+  return hs
+
+def main(name, src, out):
+  '''
+  Runs the main plotting program.
+  '''
+  for step in SETUP[name]['times']:
+    with open(f"{src}/particles{step}.json", encoding='utf-8') as f:
+      plt.figure()
+
+      # import the particle locations and height
+      data = json.loads(f.read())
+      x = data['x']
+      y = data['y']
+      z = data['z']
+      d = data['h']
+
+      # compute latitude and longitude
+      t = [math.asin(value) for value in z]
+      l = [math.atan2(y[i], x[i]) for i in range(len(x))]
+
+      # determine height to plot
+      if name == 'w5':
+        h = [d[i] + hs5(l[i], t[i]) for i in range(len(x))]
+      else:
+        h = d
+
+      # plot
+      s = plt.scatter(l, t, c=h, cmap='coolwarm', s=5, edgecolors='none')
+      cbar = plt.colorbar(s, orientation='vertical', location='right', fraction=0.05, shrink=0.675)
+      cbar.ax.set_title('[m]', pad=10)
+      color_values = [round(min(h))] + SETUP[name]['height_labels'] + [round(max(h))]
+      cbar.set_ticks(color_values)
+
+      plt.xlabel('$\\lambda$')
+      plt.ylabel('$\\theta$', rotation=0)
+      plt.xticks(ticks=[-math.pi, -math.pi/2, 0, math.pi/2, math.pi],
+                 labels=['$-180^\\circ$', '$-90^\\circ$', '0', '$90^\\circ$', '$180^\\circ$'])
+      plt.yticks(ticks=[-math.pi/2, -math.pi/4, 0, math.pi/4, math.pi/2],
+                 labels=['$-90^\\circ$', '$-45^\\circ$', '0', '$45^\\circ$', '$90^\\circ$'])
+
+      ax = plt.gca()
+      ax.tick_params(axis='x', which='both', length=0)
+      ax.tick_params(axis='y', which='both', length=0)
+
+      ax.spines[:].set_visible(False)
+      ax.spines['left'].set_position(('outward', -10))
+
+      plt.tight_layout()
+      ax.set_aspect('equal')
+      plt.savefig(f"{out}/{name}-t{step}.png", dpi=200, bbox_inches='tight', pad_inches=0.0)
+      plt.close()
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--name', help='case to plot: either w2, w5 or w6')
+  parser.add_argument('--src', help='directory containing particles*.json files')
+  parser.add_argument('--out', help='output directory for images')
+  args = parser.parse_args()
+  assert args.name and args.src and args.out
+  main(args.name, args.src, args.out)


### PR DESCRIPTION
### Summary

This PR adds some scripts to analyze results from `vortex` simulations, specifically to visualize particles or to compare the solutions with `swe-python`. Requires installing a few python modules: `pip install -r scripts/requirements.txt`.

### Testing

See the argument parser for examples of how to call the scripts. The scripts aren't tested but they were run through `pylint` which is now also included in the workflow checks.

### TODO

Extend the plotting script to add the option to either plot the particles (currently implemented) or use the Delaunay triangulation.